### PR TITLE
Write arguments to param file

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -266,6 +266,8 @@ def _mypy_aspect_impl(target, ctx):
 
     # Mypy arguments
     args = ctx.actions.args()
+    args.use_param_file("@%s", use_always = True)
+    args.set_param_file_format("multiline")
     if ctx.attr.verbose:
         args.add("--verbose")
     if strict:


### PR DESCRIPTION
Guard against hitting system argument limits by writing arguments to a file and passing that to mypy. This has a nice side effect of making it easier to see exactly what arguments were passed to mypy after the fact.